### PR TITLE
Hacky change to can.List.prototype.setup so we don't blow the stack

### DIFF
--- a/src/components/bootstrap-table/bootstrap-table.html
+++ b/src/components/bootstrap-table/bootstrap-table.html
@@ -74,6 +74,7 @@
   import getMockData from 'table-testing/data/real-getMockData';
   import initFPSCounter from 'table-testing/util/fps';
   import PerformanceMap from 'table-testing/util/performance-map';
+  import 'table-testing/util/list-fix-hack';
 
   initFPSCounter();
 
@@ -88,13 +89,12 @@
     }),
     vm = can.viewModel('.demo');
 
-
   var startIndex = 0,
       refreshIntervalDuration = 10000,
       // refreshIntervalDuration = 10000,
       cols = 20, //this is not used with real data
-      rows = 20000,
-      maxRows = 40000,
+      rows = 50000,
+      maxRows = 200000,
       // maxRows = 50000,
       mockData = getMockData(cols,rows, startIndex),
       demoVm = new DemoVM({
@@ -102,7 +102,6 @@
         tableData: mockData
       }),
       refreshInterval = setInterval(() => {
-        // debugger;
         startIndex += rows;
         if(startIndex >= maxRows){
           clearInterval(refreshInterval);
@@ -111,9 +110,12 @@
         let newData = getMockData(cols, rows, startIndex),
             tableData = demoVm.attr("tableData").attr();
 
-        tableData.rows.push.apply(tableData.rows, newData.rows);
+        debugger;
+        tableData.rows = tableData.rows.concat(newData.rows);
+        debugger;
         demoVm.attr("tableData", tableData);
-      }, refreshIntervalDuration);
+        debugger;
+  }, refreshIntervalDuration);
 
   vm.attr({
     demoVm: demoVm

--- a/src/components/bootstrap-table/bootstrap-table.viewmodel.js
+++ b/src/components/bootstrap-table/bootstrap-table.viewmodel.js
@@ -46,8 +46,7 @@ export default Map.extend({
     },
     tableRows: {
       get(){
-        let tableData = this.attr("tableData");
-        return tableData.attr("rows");
+        return this.attr("tableData.rows");
       }
     },
     performanceMap:{

--- a/src/components/bootstrap-table/extensions/bootstrap-table-refresh-data/bootstrap-table-refresh-data.js
+++ b/src/components/bootstrap-table/extensions/bootstrap-table-refresh-data/bootstrap-table-refresh-data.js
@@ -5,7 +5,7 @@
 import $ from 'jquery';
 import _ from 'lodash';
 
-var loopMax = 50000,
+var loopMax = 1000000,
     currentLoop = 0;
 
 (function ($) {

--- a/src/util/list-fix-hack.js
+++ b/src/util/list-fix-hack.js
@@ -1,0 +1,38 @@
+/**
+ * Created by nlundqu on 2017-01-19.
+ */
+
+import mapHelpers from 'can/map/map_helpers';
+
+// fixing memory issue with massive lists on setup
+// filthiest hack ever, will need to work with Justin to fix this more robustly
+can.List.prototype.setup = function(instances, options) {
+  this.length = 0;
+  can.cid(this, ".map");
+  this._setupComputedProperties();
+  instances = instances || [];
+  var teardownMapping;
+
+  if (can.isPromise(instances)) {
+    this.replace(instances);
+  } else {
+    teardownMapping = instances.length && mapHelpers.addToMap(instances, this);
+    if (instances.length > 40000) {
+      // pushing a huge amount of args at once causes the stack to explode
+      // push fewer at a time to resolve this
+      // todo: push a few thousand items at a time
+      for (var arg of instances) {
+        this.push.apply(this, [arg]);
+      }
+    } else {
+      this.push.apply(this, can.makeArray(instances || []));
+    }
+  }
+
+  if (teardownMapping) {
+    teardownMapping();
+  }
+
+  // this change needs to be ignored
+  can.simpleExtend(this, options);
+};


### PR DESCRIPTION
…while pushing huge sets of items onto the list at setup time. Table now tested up to 200k rows and its working a-ok.